### PR TITLE
use json-canon instead of canonicalize

### DIFF
--- a/lib/feed-v1/get-msg-id.js
+++ b/lib/feed-v1/get-msg-id.js
@@ -1,6 +1,6 @@
 const blake3 = require('blake3')
 const base58 = require('bs58')
-const stringify = require('canonicalize')
+const stringify = require('json-canon')
 
 /**
  * @typedef {import('./index').Msg} Msg

--- a/lib/feed-v1/index.js
+++ b/lib/feed-v1/index.js
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-only
 
-const stringify = require('canonicalize')
+const stringify = require('json-canon')
 const ed25519 = require('ssb-keys/sodium')
 const base58 = require('bs58')
 const union = require('set.prototype.union')

--- a/lib/feed-v1/represent-content.js
+++ b/lib/feed-v1/represent-content.js
@@ -1,6 +1,6 @@
 const blake3 = require('blake3')
 const base58 = require('bs58')
-const stringify = require('canonicalize')
+const stringify = require('json-canon')
 
 /**
  * @param {any} content

--- a/lib/feed-v1/validation.js
+++ b/lib/feed-v1/validation.js
@@ -1,6 +1,6 @@
 const base58 = require('bs58')
 const ed25519 = require('ssb-keys/sodium')
-const stringify = require('canonicalize')
+const stringify = require('json-canon')
 const Tangle = require('./tangle')
 const representContent = require('./represent-content')
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "async-append-only-log": "^4.3.10",
     "blake3": "^2.1.7",
     "bs58": "^5.0.0",
-    "canonicalize": "^2.0.0",
+    "json-canon": "^1.0.0",
     "obz": "^1.1.0",
     "promisify-4loc": "^1.0.0",
     "push-stream": "^11.2.0",


### PR DESCRIPTION
so i went down a big rabbit hole: [`json-canon`](https://github.com/ahdinosaur/json-canon/). :rabbit2: 

i improved performance in JavaScript (vs `canonicalize`), wrote a new serializer in Rust, and fuzzed both against all the random data i could imagine. i feel confident now about us avoiding the same serialization problem as Scuttlebutt.

so here's a pull request to use my new canonical JSON serializer, drop-in replacement as the old.